### PR TITLE
add double quote to replace-in-file param

### DIFF
--- a/packages/cli/cmd/lint.js
+++ b/packages/cli/cmd/lint.js
@@ -79,7 +79,7 @@ exports.handler = ({ concurrent, shell }) => {
       prettier && 'prettier --write',
     ],
     'yarn.lock': [
-      `replace-in-file --configFile=${yarnConfig}`,
+      `replace-in-file --configFile="${yarnConfig}"`,
       'yarn-deduplicate',
     ],
   });


### PR DESCRIPTION
Problem: `replace-in-file` breaks if configFile contains spaces.

```
> git commit --quiet --allow-empty-message --file -
husky > pre-commit (node v12.18.2)
[STARTED] Preparing...
[SUCCESS] Preparing...
[STARTED] Running tasks...
[STARTED] Running tasks for *.{vue,html,md}
[STARTED] Running tasks for *.{js,jsx,mjs,cjs}
[STARTED] Running tasks for *.{css,scss,less,xml}
[STARTED] Running tasks for {*.{json,svg},*.{to,y,ya}ml,.{babel,npm,yarn}rc,.editorconfig}
[STARTED] Running tasks for yarn.lock
[SKIPPED] No staged files match *.{vue,html,md}
[SKIPPED] No staged files match *.{css,scss,less,xml}
[STARTED] prettier --write
[STARTED] prettier --write
[STARTED] replace-in-file --configFile=C:\Users\biggates\Documents\Code Repositorie…
[FAILED] replace-in-file --configFile=C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\@nice-move\cli\lib\yarn.js [FAILED]
[FAILED] replace-in-file --configFile=C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\@nice-move\cli\lib\yarn.js [FAILED]
[SUCCESS] prettier --write
[SUCCESS] Running tasks for {*.{json,svg},*.{to,y,ya}ml,.{babel,npm,yarn}rc,.editorconfig}
[SUCCESS] prettier --write
[STARTED] eslint --fix --ext js,jsx,mjs,cjs
[SUCCESS] eslint --fix --ext js,jsx,mjs,cjs
[SUCCESS] Running tasks for *.{js,jsx,mjs,cjs}
[SUCCESS] Running tasks...
[STARTED] Applying modifications...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Reverting to original state because of errors...
[SUCCESS] Reverting to original state because of errors...
[STARTED] Cleaning up...
[SUCCESS] Cleaning up...

× replace-in-file --configFile=C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\@nice-move\cli\lib\yarn.js:
Error: Cannot find module 'C:\Users\biggates\Documents\Code'
Require stack:
- C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\replace-in-file\lib\helpers\load-config.js
- C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\replace-in-file\bin\cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)
    at Function.Module._load (internal/modules/cjs/loader.js:842:27)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at loadConfig (C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\replace-in-file\lib\helpers\load-config.js:22:10)
    at main (C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\replace-in-file\bin\cli.js:28:24)
    at Object.<anonymous> (C:\Users\biggates\Documents\Code Repositories\xxx\node_modules\replace-in-file\bin\cli.js:59:1)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'C:\\Users\\biggates\\Documents\\Code Repositories\\xxx\\node_modules\\replace-in-file\\lib\\helpers\\load-config.js',
    'C:\\Users\\biggates\\Documents\\Code Repositories\\xxx\\node_modules\\replace-in-file\\bin\\cli.js'
  ]
}
husky > pre-commit hook failed (add --no-verify to bypass)
```

Solution: addedd double quotation mark to `configFile` param.

Note: not tested yet.